### PR TITLE
automatically load riot-route

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -67,7 +67,7 @@ module.exports = {
         jquery: 'jquery',
         'window.jQuery': 'jquery',
         riot: 'riot',
-        rr: 'riot-route',
+        route: ['riot-route', 'default'],
         Popper: ['popper.js', 'default']
     })
   ]


### PR DESCRIPTION
Whenever `route` identifier is encountered, resolve it to router